### PR TITLE
Use LL_BUILD_RELEASE for macOS and Linux as well as Windows.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,7 +4,7 @@ on:
   pull_request:
   push:
     branches: [main]
-    tags: ["v*.*.*"]
+    tags: ["v*.*"]
 
 jobs:
   build:

--- a/build-cmd.sh
+++ b/build-cmd.sh
@@ -85,6 +85,6 @@ pushd "$top/luau"
     esac
 popd
 
-echo "$LUAU_VERSION.$build" > "$stage/VERSION.txt"
+echo "$LUAU_VERSION-$build" > "$stage/VERSION.txt"
 mkdir -p "$stage/LICENSES"
 cp "$top/LICENSE" "$stage/LICENSES/luau.txt"


### PR DESCRIPTION
On all platforms, use NickyD's tactic for segregating build products from source code.